### PR TITLE
Support ANSI `Vivid` Color Intensity

### DIFF
--- a/byline.cabal
+++ b/byline.cabal
@@ -177,3 +177,12 @@ executable shell
 
   if !flag(build-examples)
     buildable: False
+
+--------------------------------------------------------------------------------
+executable colors
+  import:        options, dependencies
+  main-is:       examples/colors.hs
+  build-depends: byline
+
+  if !flag(build-examples)
+    buildable: False

--- a/examples/colors.hs
+++ b/examples/colors.hs
@@ -1,0 +1,49 @@
+-- |
+--
+-- Copyright:
+--   This file is part of the package byline. It is subject to the
+--   license terms in the LICENSE file found in the top-level
+--   directory of this distribution and at:
+--
+--     https://github.com/pjones/byline
+--
+--   No part of this package, including this file, may be copied,
+--   modified, propagated, or distributed except according to the
+--   terms contained in the LICENSE file.
+--
+-- License: BSD-2-Clause
+module Main
+  ( main,
+  )
+where
+
+import Byline
+
+-- | Simple example.
+example :: MonadByline m => m ()
+example = do
+  let colors = [black, red, yellow, green, blue, cyan, magenta, white]
+
+  let w  = text "byline"
+  let fgd = mconcat $ (w <>) . fg <$> colors
+  let fgv = mconcat $ (w <>) . fg . vivid <$> colors
+  let bgd = fgd <> swapFgBg
+  let bgv = fgv <> swapFgBg
+  
+  -- show foreground colors
+  sayLn fgd
+  sayLn fgv
+  sayLn $ fgv <> underline
+  sayLn $ fgv <> bold
+  sayLn $ fgv <> underline <> bold
+  
+  -- show background colors
+  sayLn bgd
+  sayLn bgv
+  sayLn $ bgv <> underline
+  sayLn $ bgv <> bold
+  sayLn $ bgv <> underline <> bold
+
+-- | Main.
+main :: IO ()
+main = runBylineT example >> pure ()

--- a/examples/menu.hs
+++ b/examples/menu.hs
@@ -49,7 +49,7 @@ main = do
         menuBanner ("Pick a snack: " <> bold) $
           menu items
       prompt = "Which snack? " <> bold <> fg yellow
-      onError = "Please pick a valid item!" <> fg red
+      onError = "Please pick a valid item!" <> bg (vivid red)
 
   -- Display the menu and get back the item the user selected.  The
   -- user will be able to select an item using it's index, name, or

--- a/examples/simple.hs
+++ b/examples/simple.hs
@@ -39,7 +39,7 @@ main = void $
     language <- askLn question Nothing
 
     if Text.null language
-      then Exit.die ("Cat got your tongue?" <> fg magenta)
+      then Exit.die ("Cat got your tongue?" <> fg (vivid magenta))
       else sayLn ("I see, you like " <> (text language <> fg red) <> ".")
 
     -- Keep prompting until a confirmation function indicates that the

--- a/src/Byline.hs
+++ b/src/Byline.hs
@@ -49,6 +49,8 @@ module Byline
     magenta,
     cyan,
     white,
+    vivid,
+    dull,
     rgb,
   )
 where

--- a/src/Byline/Internal/Color.hs
+++ b/src/Byline/Internal/Color.hs
@@ -24,6 +24,8 @@ module Byline.Internal.Color
     magenta,
     cyan,
     white,
+    vivid,
+    dull,
     rgb,
     colorAsANSI,
     colorAsIndex256,
@@ -42,14 +44,24 @@ import qualified System.Console.ANSI as ANSI
 --
 -- @since 1.0.0.0
 black, red, green, yellow, blue, magenta, cyan, white :: Color
-black = ColorCode ANSI.Black
-red = ColorCode ANSI.Red
-green = ColorCode ANSI.Green
-yellow = ColorCode ANSI.Yellow
-blue = ColorCode ANSI.Blue
-magenta = ColorCode ANSI.Magenta
-cyan = ColorCode ANSI.Cyan
-white = ColorCode ANSI.White
+black = ColorCode ANSI.Dull ANSI.Black
+red = ColorCode ANSI.Dull ANSI.Red
+green = ColorCode ANSI.Dull ANSI.Green
+yellow = ColorCode ANSI.Dull ANSI.Yellow
+blue = ColorCode ANSI.Dull ANSI.Blue
+magenta = ColorCode ANSI.Dull ANSI.Magenta
+cyan = ColorCode ANSI.Dull ANSI.Cyan
+white = ColorCode ANSI.Dull ANSI.White
+
+-- | Intensify an ANSI color.
+vivid :: Color -> Color
+vivid (ColorCode _ c) = ColorCode ANSI.Vivid c
+vivid c = c
+
+-- | Dull an ANSI color.
+dull :: Color -> Color
+dull (ColorCode _ c) = ColorCode ANSI.Dull c
+dull c = c
 
 -- | Specify a color using a RGB triplet where each component is in
 -- the range @[0 .. 255]@.  The actual rendered color will depend on
@@ -81,7 +93,7 @@ rgb r g b = ColorRGB (r, g, b)
 --
 -- @since 1.0.0.0
 colorAsANSI :: Color -> ANSI.Color
-colorAsANSI (ColorCode c) = c
+colorAsANSI (ColorCode _ c) = c
 colorAsANSI (ColorRGB c) = nearestColor c ansiColorLocations
 
 -- | Convert a Byline color to an index into a terminal 256-color palette.
@@ -89,7 +101,7 @@ colorAsANSI (ColorRGB c) = nearestColor c ansiColorLocations
 -- @since 1.0.0.0
 colorAsIndex256 :: Color -> Word8
 colorAsIndex256 = \case
-  ColorCode c -> ANSI.xtermSystem ANSI.Dull c
+  ColorCode i c -> ANSI.xtermSystem i c
   ColorRGB c -> nearestColor c term256Locations
 
 -- | Convert a Byline color to a 'C.Colour'.  If the color is
@@ -97,9 +109,9 @@ colorAsIndex256 = \case
 -- instead.  This allows the terminal to pick the color on its own.
 --
 -- @since 1.0.0.0
-colorAsRGB :: Color -> Either ANSI.Color (C.Colour Float)
+colorAsRGB :: Color -> Either (ANSI.ColorIntensity, ANSI.Color) (C.Colour Float)
 colorAsRGB = \case
-  ColorCode c -> Left c
+  ColorCode i c -> Left (i,c)
   ColorRGB (r, g, b) -> Right (C.sRGB24 r g b)
 
 -- | Find the nearest color given a full RGB color.

--- a/src/Byline/Internal/Stylized.hs
+++ b/src/Byline/Internal/Stylized.hs
@@ -192,7 +192,9 @@ renderInstructions mode = \case
           [RenderText t]
         Simple ->
           -- Terminal supports basic 16 colors.
-          let color l = ANSI.SetColor l ANSI.Dull . Color.colorAsANSI
+          let color l c = case c of
+                Color.ColorCode ai ac -> ANSI.SetColor l ai ac
+                rgb -> ANSI.SetColor l ANSI.Dull (Color.colorAsANSI rgb)
            in renderToSGR t m color
         Term256 ->
           -- Terminal supports the 256-color palette.
@@ -201,7 +203,7 @@ renderInstructions mode = \case
         TermRGB ->
           -- Super terminal!
           let color l c = case Color.colorAsRGB c of
-                Left ac -> ANSI.SetColor l ANSI.Dull ac
+                Left (ai,ac) -> ANSI.SetColor l ai ac
                 Right rgb -> ANSI.SetRGBColor l rgb
            in renderToSGR t m color
     renderToSGR ::

--- a/src/Byline/Internal/Types.hs
+++ b/src/Byline/Internal/Types.hs
@@ -33,7 +33,7 @@ import qualified System.Console.ANSI as ANSI
 --
 -- @since 1.0.0.0
 data Color
-  = ColorCode ANSI.Color
+  = ColorCode ANSI.ColorIntensity ANSI.Color
   | ColorRGB (Word8, Word8, Word8)
   deriving (Show, Eq)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,7 +29,7 @@ example = do
         "What's "
           <> ("your" <> bold)
           <> " favorite "
-          <> ("language" <> fg green <> underline)
+          <> ("language" <> fg (vivid green) <> underline)
           <> "? "
 
   askLn question (Just "Haskell")


### PR DESCRIPTION
Resolves #19 .  Adds support for vivid/dull color intensities as described by [`System.Console.ANSI`](https://hackage.haskell.org/package/ansi-terminal-0.5.0/docs/System-Console-ANSI.html#t:SGR), increasing the basic color count from 8 to 16.

This implementation is slightly different from the proposal I made yesterday.  Instead of adding a new modifier, the `ColorCode` constructor now takes both an intensity and an ANSI color.  This makes more sense to me, since `Color` and `ColorIntensity` are always [provided together](https://hackage.haskell.org/package/ansi-terminal-0.5.0/docs/System-Console-ANSI.html#t:SGR) in the `SGR` command.

Pre-defined colors (`red`, `white`, etc.) default to `ANSI.Dull`, and but there are two functions `vivid :: Color -> Color` and `dull :: Color -> Color` that change the intensity.  Example usage:

```haskell
sayLn (text "byline" <> fg (vivid red))
```

I added a new usage example that prints all the colors.  Here's the output on my Ubuntu bash terminal:

![image](https://user-images.githubusercontent.com/221963/124114257-524b6b00-daa7-11eb-8bb0-f4f6c0596717.png)

The following might need attention:

* After my changes, the [`colorAsANSI`](https://github.com/benrbray/byline/blob/trunk/src/Byline/Internal/Color.hs#L95) function is now [only ever called on a `ColorRGB`](https://github.com/benrbray/byline/blob/trunk/src/Byline/Internal/Stylized.hs#L195).  It's also gives the "wrong" answer on a `ColorCode` with vivid intensity, because the intensity is discarded.

* It might also make sense to add `vividfg` and `vividbg` modifiers so that differently-colored text can all be intensified at once.  However, these wouldn't be well-defined operations on a `ColorRGB` color.

* Do any of the documentation / internal comments need to be updated to reflect this change?

* Locally, I made a few changes to the config files to help HLS understand the `/examples` folder.  Unless you'd like me to include those changes here, I figured it would be better to submit a followup PR.
  * I changed `hie.yaml` to include a `component` for each example
  * I added a `cabal.project.local` with the contents `flag: +build-examples` 
  * These changes did not impact the result of running `cabal v2-sdist`

Feedback on the code is most welcome, as I'm relatively new to writing Haskell.  Thanks!