### PR TITLE
Rectify `Stylized` Semigroup Instance  

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ for input, and generating custom menus.  It was inspired by the
 ```haskell
 example :: MonadByline m => m Text
 example = do
-  sayLn ("Hey, I like " <> ("Haskell" <> fg magenta) <> "!")
+  sayLn ("Hey, I like " <> ("Haskell" & fg magenta) <> "!")
 
   let question =
         "What's "
-          <> ("your" <> bold)
+          <> ("your" & bold)
           <> " favorite "
-          <> ("language" <> fg green <> underline)
+          <> ("language" & fg green & underline)
           <> "? "
 
   askLn question (Just "Haskell")

--- a/examples/colors.hs
+++ b/examples/colors.hs
@@ -23,26 +23,11 @@ import Byline
 example :: MonadByline m => m ()
 example = do
   let colors = [black, red, yellow, green, blue, cyan, magenta, white]
-
-  let w  = text "byline"
-  let fgd = mconcat $ (w &) . fg <$> colors
-  let fgv = mconcat $ (w &) . fg . vivid <$> colors
-  let bgd = swapFgBg fgd 
-  let bgv = swapFgBg fgv
-  
-  -- show foreground colors
-  sayLn fgd
-  sayLn fgv
-  sayLn $ fgv & underline
-  sayLn $ fgv & bold
-  sayLn $ fgv & underline & bold
-  
-  -- show background colors
-  sayLn bgd
-  sayLn bgv
-  sayLn $ bgv & underline
-  sayLn $ bgv & bold
-  sayLn $ bgv & underline & bold
+  let styles = [id, underline, bold, bold . underline]
+  let intensity = [id, vivid]
+  let fgbg = [id, swapFgBg]
+  let mods = [ (text "byline" &) <$> [fb . fg (i c) . s | c <- colors] | fb <- fgbg, i <- intensity, s <- styles]
+  mapM_ (sayLn . fold) mods
 
 -- | Main.
 main :: IO ()

--- a/examples/colors.hs
+++ b/examples/colors.hs
@@ -25,24 +25,24 @@ example = do
   let colors = [black, red, yellow, green, blue, cyan, magenta, white]
 
   let w  = text "byline"
-  let fgd = mconcat $ (w <>) . fg <$> colors
-  let fgv = mconcat $ (w <>) . fg . vivid <$> colors
-  let bgd = fgd <> swapFgBg
-  let bgv = fgv <> swapFgBg
+  let fgd = mconcat $ (w &) . fg <$> colors
+  let fgv = mconcat $ (w &) . fg . vivid <$> colors
+  let bgd = swapFgBg fgd 
+  let bgv = swapFgBg fgv
   
   -- show foreground colors
   sayLn fgd
   sayLn fgv
-  sayLn $ fgv <> underline
-  sayLn $ fgv <> bold
-  sayLn $ fgv <> underline <> bold
+  sayLn $ fgv & underline
+  sayLn $ fgv & bold
+  sayLn $ fgv & underline & bold
   
   -- show background colors
   sayLn bgd
   sayLn bgv
-  sayLn $ bgv <> underline
-  sayLn $ bgv <> bold
-  sayLn $ bgv <> underline <> bold
+  sayLn $ bgv & underline
+  sayLn $ bgv & bold
+  sayLn $ bgv & underline & bold
 
 -- | Main.
 main :: IO ()

--- a/examples/demo.hs
+++ b/examples/demo.hs
@@ -22,13 +22,13 @@ import Byline
 -- | Simple example.
 example :: MonadByline m => m Text
 example = do
-  sayLn ("Hey, I like " <> ("Haskell" <> fg magenta) <> "!")
+  sayLn ("Hey, I like " <> ("Haskell" & fg magenta) <> "!")
 
   let question =
         "What's "
-          <> ("your" <> bold)
+          <> ("your" & bold)
           <> " favorite "
-          <> ("language" <> fg green <> underline)
+          <> ("language" & fg green & underline)
           <> "? "
 
   askLn question (Just "Haskell")

--- a/examples/menu.hs
+++ b/examples/menu.hs
@@ -29,8 +29,8 @@ data Item
 -- | How to display a menu item.
 instance ToStylizedText Item where
   toStylizedText item = case item of
-    Fruit name -> text name <> (" (fruit)" <> fg red)
-    Vegetable name -> text name <> (" (vegetable)" <> fg green)
+    Fruit name -> text name <> (" (fruit)" & fg red)
+    Vegetable name -> text name <> (" (vegetable)" & fg green)
 
 -- | The list of menu items.
 items :: NonEmpty Item
@@ -46,10 +46,10 @@ items =
 main :: IO ()
 main = do
   let menuConfig =
-        menuBanner ("Pick a snack: " <> bold) $
+        menuBanner ("Pick a snack: " & bold) $
           menu items
-      prompt = "Which snack? " <> bold <> fg yellow
-      onError = "Please pick a valid item!" <> bg (vivid red)
+      prompt = "Which snack? " & bold & fg yellow
+      onError = "Please pick a valid item!" & bg (vivid red)
 
   -- Display the menu and get back the item the user selected.  The
   -- user will be able to select an item using it's index, name, or

--- a/examples/simple.hs
+++ b/examples/simple.hs
@@ -25,7 +25,7 @@ main :: IO ()
 main = void $
   runBylineT $ do
     -- Start with a simple message to standard output:
-    sayLn ("I can use " <> ("color" <> fg blue) <> "!")
+    sayLn ("I can use " <> ("color" & fg blue) <> "!")
 
     -- When not using any stylized modifiers you can use the `text'
     -- helper function to avoid "Ambiguous type variable":
@@ -34,26 +34,26 @@ main = void $
     -- Get user input with a stylized prompt:
     let question =
           "What's your favorite "
-            <> ("language" <> bold <> fg green)
+            <> ("language" & bold & fg green)
             <> "? "
     language <- askLn question Nothing
 
     if Text.null language
-      then Exit.die ("Cat got your tongue?" <> fg (vivid magenta))
-      else sayLn ("I see, you like " <> (text language <> fg red) <> ".")
+      then Exit.die ("Cat got your tongue?" & fg (vivid magenta))
+      else sayLn ("I see, you like " <> (text language & fg red) <> ".")
 
     -- Keep prompting until a confirmation function indicates that the
     -- user's input is sufficient:
     let question =
           "What's your "
-            <> ("name" <> fg green <> underline)
+            <> ("name" & fg green & underline)
             <> "? "
     name <- askUntil question Nothing (pure . atLeastThreeChars)
-    sayLn $ "Hey there " <> text name <> fg (rgb 108 113 196)
+    sayLn $ "Hey there " <> text name & fg (rgb 108 113 196)
 
 -- | Example confirmation function that requires the input to be three
 -- or more characters long.
 atLeastThreeChars :: Text -> Either (Stylized Text) Text
 atLeastThreeChars input
-  | Text.length input < 3 = Left ("You can do better." <> bg red)
+  | Text.length input < 3 = Left ("You can do better." & bg red)
   | otherwise = Right input

--- a/src/Byline/Shell.hs
+++ b/src/Byline/Shell.hs
@@ -144,7 +144,7 @@ shellSplit t =
         then pure []
         else case Atto.parseOnly go input of
           Left e -> do
-            sayLn (("invalid input" <> fg red) <> ": " <> text (toText e))
+            sayLn (("invalid input" & fg red) <> ": " <> text (toText e))
             pure []
           Right ws ->
             pure ws

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -23,13 +23,13 @@ import Test.Tasty.HUnit
 
 example :: MonadByline m => m Text
 example = do
-  sayLn ("Hey, I like " <> ("Haskell" <> fg magenta) <> "!")
+  sayLn ("Hey, I like " <> ("Haskell" & fg magenta) <> "!")
 
   let question =
         "What's "
-          <> ("your" <> bold)
+          <> ("your" & bold)
           <> " favorite "
-          <> ("language" <> fg (vivid green) <> underline)
+          <> ("language" & fg (vivid green) & underline)
           <> "? "
 
   askLn question (Just "Haskell")


### PR DESCRIPTION
Resolves #16 based on the proposed suggestion to make modifiers functions `Stylized Text -> Stylized Text` instead of using a separate `StylizedMod` constructor for `Stylized`.  As a result of this change, modifiers need to be applied by function application, rather than `<>`, which is a **breaking change**.  I also added more color combinations to the colors example, since I had to modify the file anyway.

```haskell
example :: MonadByline m => m Text
example = do
  sayLn ("Hey, I like " <> ("Haskell" & fg magenta) <> "!")

  let question =
        "What's "
          <> ("your" & bold)
          <> " favorite "
          <> ("language" & fg green & underline)
          <> "? "

  askLn question (Just "Haskell")
```

I made this PR with minimal changes, but notice now that the `fg`, `bg`, `bold`, `underline`, and `swapFgBg` functions all have pretty similar, boilerplate implementations.  Now that `Stylized` no longer has a `StylizedMod` constructor, it makes me think that maybe rewriting the data type might lead to a simpler implementation.  

Alternatively we can reduce the boilerplate this way, but maybe there's a more idiomatic way to do this than with these lambdas. 
 Let me know what you prefer!

```haskell
modifier :: (Modifier -> Modifier) -> Stylized Text -> Stylized Text
modifier f (Stylized m t) = Stylized (f m) t
modifier f (StylizedList l) = StylizedList (map (modifier f) l)

fg :: Color -> Stylized Text -> Stylized Text
fg c = modifier (\m -> m {modColorFG = OnlyOne (Just c)})

bg :: Color -> Stylized Text -> Stylized Text
bg c = modifier (\m -> m {modColorBG = OnlyOne (Just c)})

bold :: Stylized Text -> Stylized Text
bold = modifier (\m -> m {modBold = On})

underline :: Stylized Text -> Stylized Text
underline = modifier (\m -> m {modUnderline = On})

swapFgBg :: Stylized Text -> Stylized Text
swapFgBg = modifier (\m -> m {modSwapFgBg = On})
```

