### PR TITLE
GHC 9.2.5 Support

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Haskell
         id: setup-haskell-cabal
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         with:
           ghc-version: 8.10
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,18 +10,18 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         cabal: ["3.4"]
-        ghc: ["8.8", "8.10", "9.0"]
+        ghc: ["8.8", "8.10", "9.0", "9.2.5"]
         exclude:
           # https://gitlab.haskell.org/ghc/ghc/-/issues/17926
           - os: windows-latest
             ghc: "8.8"
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Haskell
         id: setup-haskell-cabal
-        uses: haskell/actions/setup@v1
+        uses: haskell/actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
@@ -32,7 +32,7 @@ jobs:
           cabal freeze
 
       - name: Cache ~/.cabal/store
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
@@ -44,7 +44,7 @@ jobs:
         run: cabal test
 
       - name: Upload Build Logs on Failure
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs-${{ matrix.os }}-ghc${{ matrix.ghc }}
@@ -54,7 +54,7 @@ jobs:
         run: cabal install --installdir=artifacts --install-method=copy
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}-ghc${{ matrix.ghc }}
           path: artifacts/

--- a/byline.cabal
+++ b/byline.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               byline
-version:            1.2.0
+version:            1.1.2
 homepage:           https://github.com/pjones/byline
 bug-reports:        https://github.com/pjones/byline/issues
 license:            BSD-2-Clause

--- a/byline.cabal
+++ b/byline.cabal
@@ -1,17 +1,17 @@
 cabal-version:      2.2
 name:               byline
-version:            1.1.1
+version:            1.2.0
 homepage:           https://github.com/pjones/byline
 bug-reports:        https://github.com/pjones/byline/issues
 license:            BSD-2-Clause
 license-file:       LICENSE
 author:             Peter Jones <pjones@devalot.com>
 maintainer:         Peter Jones <pjones@devalot.com>
-copyright:          Copyright: (c) 2015-2021 Peter J. Jones
+copyright:          Copyright: (c) 2015-2023 Peter J. Jones
 category:           System, User Interfaces
 build-type:         Simple
 stability:          stable
-tested-with:        GHC ==8.8.4 || ==8.10.4 || ==9.0.1
+tested-with:        GHC ==8.8.4 || ==8.10.4 || ==9.0.1 || ==9.2.5 || ==9.4.4
 synopsis:
   Library for creating command-line interfaces (colors, menus, etc.)
 
@@ -101,12 +101,12 @@ common dependencies
     , colour                ^>=2.3
     , exceptions            >=0.8  && <0.11
     , free                  ^>=5.1
-    , haskeline             >=0.8  && <0.8.2
+    , haskeline             >=0.8  && <0.8.3
     , mtl                   >=2.1  && <2.3
-    , optparse-applicative  ^>=0.16
-    , relude                >=0.6  && <1.1
+    , optparse-applicative  ^>=0.17
+    , relude                >=0.6  && <1.2
     , terminfo-hs           >=0.1  && <0.3
-    , text                  >=0.11 && <1.3
+    , text                  >=0.11 && <2.0
 
   mixins:
     base hiding (Prelude),

--- a/examples/colors.hs
+++ b/examples/colors.hs
@@ -18,6 +18,7 @@ module Main
 where
 
 import Byline
+import Control.Monad
 
 -- | Simple example.
 example :: MonadByline m => m ()
@@ -31,4 +32,4 @@ example = do
 
 -- | Main.
 main :: IO ()
-main = runBylineT example >> pure ()
+main = Control.Monad.void (runBylineT example)


### PR DESCRIPTION
This introduces support for GHC 9.2.5, the penultimate stable release of GHC. 
I could not support GHC 9.4.4; [Relude does not support it yet](https://github.com/kowainik/relude/pull/421).

Summary of changes:
- Updated the bare minimum dependencies to get Byline to compile on 9.2.5 (locally and CI)
- Added 9.2.5 to the test matrix
- Updated deprecated GitHub actions so the CI won't break in the future
- Fixed an example that was failing the linter
- Updated copyright notice to 2023, and bumped version to 1.2.0 (as per PVP)

I noticed that the previous dependency update changed some Nix files.
I have not worked with Nix before, so if anything needs to be run/updated in that regard, could you point me in the right direction?